### PR TITLE
Add TLS and Port Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,30 @@
 - Zabbix Server Version: 7
 - Zabbix Sender Version: 6.4.7
 
-This template is in development with Zabbix Server version 7. Zabbix Server Version 6 with the templates from here may not working properly.
+This template is in development with Zabbix Server version 7. To get it working under Zabbix Server Version 6 just change the `version` key at the beginning. However they may not work properly.
 
 ## Setup
-1. Copy the content from the docker-compose.yml file to your local docker-compose.yml file and fillout the environment variables with yours.
-2. Download the Zabbix template file from [template_fritz.box.xml](https://github.com/pthoelken/fritzbox-zabbix-monitoring/blob/master/templates) and import it to your Zabbix Monitoring system (if you update, delete the old tempalte first)
-3. Create a host in zabbix with the same hostname from docker-compose.yml (```FRITZBOX_HOSTNAME```)
-4. Start your docker-compose file with ```docker-compose up -d```
-5. You can check the container with ```docker-compose logs``` into the same directory
+1. Create a user for monitoring (with settings permissions) in your FritzBox
+1. Copy the content from the docker-compose.yml file to your local `docker-compose.yaml`` file and fillout the environment variables. You can leave some blank to use defaults (see below).
+1. Download the Zabbix template file from [template_fritz.box.xml](https://github.com/pthoelken/fritzbox-zabbix-monitoring/blob/master/templates) and import it to your Zabbix Monitoring system (if you update, delete the old tempalte first)
+1. Create a host in zabbix with the same hostname from docker-compose.yml (```FRITZBOX_HOSTNAME```)
+1. Start your docker-compose file with ```docker-compose up -d```
+1. You can check the container with ```docker-compose logs``` into the same directory
+
+### Environment Variables
+
+|  Key  |  Default  |  Comment  |
+| ----- | --------- | --------- |
+|  ZABBIX_SERVER  |  -  |  IP address of your Zabbix server  |
+|  ZABBIX_SERVER_PORT  |  10050  |  Custom port of your Zabbix server  |
+|  TLS_PSK_IDENTITY  |  (not used)  |  ID of the pre-shared-key to be used  |
+|  TLS_PSK_  |  (not used)  |  Secret of the pre-shared-key  |
+|  INTERVAL  |  -  |  Check intervall  |
+|  FRITZBOX_HOSTNAME  |  -  |  Hostname of your FritzBox at the Zabbix Server  |
+|  FRITZBOX_IP  |  -  |  IP address of your FritzBox where it could be reached from this check service  |
+|  FRITZBOX_USER  |  -  |  User in your FritzBox for this check service  |
+|  FRITZBOX_PASSWD  |  -  |  Password in your FritzBox for this check service  |
+|  ZABBIX_SENDER_DEBUG  |  False  |  Switch to enable verbose logging  |
 
 ## For builders and developers only
 1. ```git clone XX```

--- a/container/bin/send
+++ b/container/bin/send
@@ -1,14 +1,36 @@
 #!/bin/ash
 
+# Concat the sender command with env vars
+ZBX_SEND="zabbix_sender -z $ZABBIX_SERVER -i -"
+
+# - custom port
+if [[ ! -z $ZABBIX_SERVER_PORT ]]; then
+	echo "Using custom Zabbix Server port '$ZABBIX_SERVER_PORT'"
+	ZBX_SEND="${ZBX_SEND} -p ${ZABBIX_SERVER_PORT}"
+fi
+
+# - TLS with PSK
+if [[ ! -z $TLS_PSK_IDENTITY ]] && [[ ! -z $TLS_PSK ]]; then
+	echo "Using TLS with PSK"
+	echo "${TLS_PSK}" > /app/psk.file
+	ZBX_SEND="${ZBX_SEND} --tls-connect psk --tls-psk-file /app/psk.file --tls-psk-identity $TLS_PSK_IDENTITY"
+fi
+
+# - Verbose/Degub logging
+if [ "$ZABBIX_SENDER_DEBUG" == "True" ]; then
+	echo "Enable verbose logging"
+	ZBX_SEND="${ZBX_SEND} -vv"
+	echo "Using the following send command: ${ZBX_SEND}"
+fi
+
+
+# Check and Loop
 while true; do
 
-	if [ "$ZABBIX_SENDER_DEBUG" == "True" ]; then
-		php status.php | zabbix_sender -vv -z $ZABBIX_SERVER -i -
-	else
-		php status.php | zabbix_sender -z $ZABBIX_SERVER -i -
-	fi
+	php status.php | $ZBX_SEND
 
 	sleep $INTERVAL &
 	wait $!
+
 done
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,13 +1,16 @@
 version: '3.2'
 services:
-  fritzbox-zabbix-monitoring:
+  monitor:
     image: pthoelken/fritzbox-zabbix-monitoring:latest
     restart: always
     environment:
       - ZABBIX_SERVER=000.000.000.000
+      - ZABBIX_SERVER_PORT=
+      - TLS_PSK_IDENTITY=
+      - TLS_PSK=
+      - INTERVAL=30s
       - FRITZBOX_HOSTNAME=fritz.box
       - FRITZBOX_IP=000.000.000.000
-      - INTERVAL=30s
       - FRITZBOX_USER=zabbixmonitor
       - FRITZBOX_PASSWD=changeme
-      - ZABBIX_SENDER_DEBUG=True
+      - ZABBIX_SENDER_DEBUG=False


### PR DESCRIPTION
## Changes

- close #14 

### Added

- add TLS PSK support:
  - create two env vars (id and secret)
  - TLS is only used when both have values
- add a port settings for the Zabbix server
  - port is only used if set

### Modified

- `Readme.md`:
  - add a missing point "Create a FritzBox user"
  - add a table with explanations of the env vars
- `send`: (refactored)
  - be more verbose at startup
  - keeps the send command dynamic in case we want to add even more features to it
  - shows the final send command in `debug`