### PR TITLE
Gracefully handle unsupported service or action in safe_call

### DIFF
--- a/src/fritzbox_monitor.py
+++ b/src/fritzbox_monitor.py
@@ -103,6 +103,12 @@ _wlan_signal_by_mac = {}  # {mac_lower: signal_strength_percent}
 # TR-064 Interface
 # ===================================================================
 def safe_call(fc, service, action, arguments=None):
+    if service not in fc.services:
+        log.debug("Service %s not supported", service)
+        return None
+    if action not in fc.services[service].actions:
+        log.debug("Action %s in service %s not supported", action, service)
+        return None
     try:
         return fc.call_action(service, action, arguments=arguments) if arguments else fc.call_action(service, action)
     except Exception as e:


### PR DESCRIPTION
An unsupported service would be caught by fritzconnection, but an unsupported action generates a (needlessly failing) request to the Fritz!Box.